### PR TITLE
Devconf slide fixes

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -14,3 +14,8 @@
     Permissions-Policy = "camera=(), microphone=(), geolocation=()"
     X-XSS-Protection = "1; mode=block"
     Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://cal.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https: data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.listenbrainz.org https://coverartarchive.org https://itunes.apple.com https://api.github.com https://wakatime.com; frame-src https://cal.com;"
+
+[[headers]]
+  for = "/talks/*"
+  [headers.values]
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://fonts.googleapis.com; img-src 'self' https: data:; font-src 'self' https://fonts.gstatic.com https://fonts.googleapis.com; connect-src 'self';"

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -1,5 +1,23 @@
 [
   {
+    "name": "DevConf.CZ 2026",
+    "date": "2026-06-18",
+    "location": "Brno, Czech Republic",
+    "role": "speaker",
+    "talk": "Lost in Transliteration: Why strlen(\"Dvořák\") Returns 8",
+    "description": "A deep dive into character encoding, Unicode, and how glibc's iconv handles text conversion internally — from the ASCII era through code pages to the gconv pipeline.",
+    "links": [
+      {
+        "label": "Slides",
+        "url": "/talks/devconf-2026/"
+      },
+      {
+        "label": "Event Page",
+        "url": "https://pretalx.devconf.info/devconf-cz-2026/talk/review/JVY7TPFMDDAPWUKHAPDH3MDKVZUXLDEW"
+      }
+    ]
+  },
+  {
     "name": "Opportunity Open Source Conference 2024",
     "date": "2024-08-25",
     "location": "IIT Kanpur, India",


### PR DESCRIPTION
- **Allow CDN scripts/styles for /talks/* in CSP header**
- **Add DevConf.CZ 2026 talk to events page**
